### PR TITLE
Ensure that 'yarn run watch' works with hard links

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,7 +25,10 @@ function mindlesslyFactoredOutSettings(name) {
             json(),
             globals(),
             builtins()
-        ]
+        ],
+        watch: {
+            chokidar: false
+        }
     }
 }
 


### PR DESCRIPTION
This makes it possible for 'yarn run watch' to correctly detect file changes when a Fathom project's source 'trainees.js' is hardlinked to fathom-trainees' target 'trainees.js', even if that source 'trainees.js' has 'import' statements. Any changes to the imported files will also be correctly detected as a file change.

See https://github.com/mozilla/fathom-trainees/issues/8#issuecomment-541253062 for more information.